### PR TITLE
fix: DuplicatesStrategy.INCLUDE must be set when merging service files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,11 @@ jar {
 shadowJar {
     zip64 true
     archiveClassifier.set(null)
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
+    exclude("META-INF/*.SF")
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra/issues/12253
