### PR TITLE
fix(plugin-graalvm): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/graalvm/js/package-info.java
+++ b/src/main/java/io/kestra/plugin/graalvm/js/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-        title = "JavaScript tasks on GraalVM",
+        title = "JS - GraalVM",
         description = "Tasks that run JavaScript in-process on GraalVM, including inline evaluation and file transformations.",
         categories = { PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.INFRASTRUCTURE }
 )

--- a/src/main/java/io/kestra/plugin/graalvm/python/package-info.java
+++ b/src/main/java/io/kestra/plugin/graalvm/python/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-        title = "Python tasks on GraalVM",
+        title = "Python - GraalVM",
         description = "Tasks that run Python in-process on GraalVM for inline evaluation and file transformations.",
         categories = { PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.INFRASTRUCTURE }
 )

--- a/src/main/java/io/kestra/plugin/graalvm/ruby/package-info.java
+++ b/src/main/java/io/kestra/plugin/graalvm/ruby/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-        title = "Ruby tasks on GraalVM",
+        title = "Ruby - GraalVM",
         description = "Tasks that run Ruby in-process on GraalVM for inline evaluation and file transformations.",
         categories = { PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.INFRASTRUCTURE }
 )


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge