### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=1.5.3-SNAPSHOT
-kestraVersion=1.3.0
+kestraVersion=1.3.19
 graalVMVersion=24.2.2

--- a/src/main/java/io/kestra/plugin/graalvm/AbstractFileTransform.java
+++ b/src/main/java/io/kestra/plugin/graalvm/AbstractFileTransform.java
@@ -56,9 +56,9 @@ public abstract class AbstractFileTransform extends AbstractScript implements Ru
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
         var source = generateSource(languageId, runContext);
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             if (from.startsWith("kestra://")) {
-                try (BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(URI.create(from))), FileSerde.BUFFER_SIZE)) {
+                try (var inputStream = new BufferedInputStream(runContext.storage().getFile(URI.create(from)), FileSerde.BUFFER_SIZE)) {
                     this.finalize(
                             runContext,
                             FileSerde.readAll(inputStream),
@@ -96,7 +96,7 @@ public abstract class AbstractFileTransform extends AbstractScript implements Ru
         RunContext runContext,
         Flux<Object> flowable,
         Source scripts,
-        Writer output
+        OutputStream output
     ) throws IOException, IllegalVariableEvaluationException, InterruptedException {
         Thread stdOut = null;
         Thread stdErr = null;

--- a/src/test/java/io/kestra/plugin/graalvm/js/FileTransformTest.java
+++ b/src/test/java/io/kestra/plugin/graalvm/js/FileTransformTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.graalvm.js;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.IdUtils;
@@ -11,6 +12,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -65,6 +69,14 @@ public class FileTransformTest {
                     {date:"2025-03-19",title:"Apple_Network_Server",views:1835,time:"12:00:00Z"}
                     {date:"2025-03-19",title:"ChatGPT",views:1715,time:"12:00:00Z"}
                     {date:"2025-03-19",title:"Portal:Current_events",views:1462,time:"12:00:00Z"}"""));
+            }
+
+            // Verify structured ION deserialization works (ION binary migration validation)
+            try (InputStream ionIs = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, output.getUri()), FileSerde.BUFFER_SIZE)) {
+                List<Object> result = new ArrayList<>();
+                FileSerde.read(ionIs, result::add);
+                assertThat(result.size(), is(7));
+                assertThat(((Map<String, Object>) result.get(0)).get("title"), is("Sunita_Williams"));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155)
- Bump kestraVersion from 1.3.0 to 1.3.19
- Replace `BufferedWriter`/`FileWriter` with `BufferedOutputStream`/`FileOutputStream` and `BufferedReader`/`InputStreamReader` with `BufferedInputStream` in `AbstractFileTransform.java`

## Test plan
- [x] Build passes (`./gradlew clean build -x test shadowJar`)
- [ ] Run existing integration tests against updated plugin